### PR TITLE
Add the pyrise wrapper for Highrise

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -142,13 +142,17 @@ Hi. Below you will find a list of web services along with links to their docs an
 - [API Documentation](https://developers.google.com/google-apps/spreadsheets/)
 - [Python wrapper for Google Spreadsheet](https://github.com/yoavaviram/python-google-spreadsheet)
 
+### [Hadoop YARN](http://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/YARN.html) - Apache Hadoop NextGen MapReduce (YARN)
+- [API Documentation](http://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html)
+- [Python wrapper for Hadoop YARN](https://pypi.python.org/pypi/yarn-api-client)
+
 ### [Heroku](https://www.heroku.com/) - Cloud Application Platform
 - [API Documentation](https://devcenter.heroku.com/articles/platform-api-reference)
 - [Python wrapper for Heroku](https://pypi.python.org/pypi/heroku)
 
-### [Hadoop YARN](http://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/YARN.html) - Apache Hadoop NextGen MapReduce (YARN)
-- [API Documentation](http://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html)
-- [Python wrapper for Hadoop YARN](https://pypi.python.org/pypi/yarn-api-client)
+### [Highrise](https://highrisehq.com/) - Contact management tool (CRM)
+- [API Documentation](https://github.com/basecamp/highrise-api)
+- [Python wrapper for Highrise](https://github.com/feedmagnet/pyrise)
 
 ### [HipChat](https://www.hipchat.com/) - Hosted group chat and IM
 - [API Documentation](https://www.hipchat.com/docs/api)


### PR DESCRIPTION
This PR adds links to the Highrise API documentation and the Python wrapper, the super-cleverly-named pyrise.