### PR TITLE
ESPN no longer an option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -94,10 +94,6 @@ Hi. Below you will find a list of web services along with links to their docs an
 - [API Documentation](http://embed.ly/docs/embed/api/endpoints/1/oembed)
 - [Python wrapper for Embedly](https://github.com/embedly/embedly-python)
 
-### [ESPN](http://www.espn.com) - Television Channel
-- [API Documentation](http://developer.espn.com/docs)
-- [Python wrapper for ESPN](https://github.com/tixocloud/espyn)
-
 ### [Evernote](http://www.evernote.com/) - Notetaking software
 - [API Documentation](http://dev.evernote.com/doc/)
 - [Python Wrapper for Evernote](https://github.com/evernote/evernote-sdk-python)


### PR DESCRIPTION
ESPN has discontinued their public APIs.

http://espn.go.com/static/apis/devcenter/blog/read/publicretirement.html
Signed-off-by: Chris May <chris@punchrva.com>