### PR TITLE
Replace boxdotcom with the official Box SDK

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,7 @@ Hi. Below you will find a list of web services along with links to their docs an
 
 ### [Box](https://www.box.com/) - Online file sharing
 - [API Documentation](http://developers.box.com/)
-- [Python wrapper for Box](https://pypi.python.org/pypi/boxdotcom)
+- [Python wrapper for Box](https://github.com/box/box-python-sdk)
 
 ### [Braintree](https://www.braintreepayments.com/) - Accept Payments Online
 - [API Documentation](https://www.braintreepayments.com/developers)


### PR DESCRIPTION
Hey team -- was working on a Box-related project today and I turned to this trusty list of API wrappers (per usual)...

When reviewing Box's own documentation, however, I noticed that they had built their own Python SDK! This update adjusts the linked API wrapper from [`boxdotcom`](https://github.com/dvska/python-boxdotcom), which has gone a bit stale, to the official Box-implemented SDK.