### PR TITLE
Add Skyscanner

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -277,6 +277,10 @@ Hi. Below you will find a list of web services along with links to their docs an
 ### [Scrapinghub](http://scrapinghub.com/) - Scraping services
 - [API Documentation](http://doc.scrapinghub.com/api.html)
 - [Python wrapper for Scrapinghub](https://github.com/scrapinghub/python-scrapinghub)
+ 
+### [Skyscanner](http://www.skyscanner.net/) - Travel metasearch
+- [API Documentation](http://business.skyscanner.net/portal/en-GB/Documentation/ApiOverview)
+- [Python wrapper for Skyscanner](https://github.com/Skyscanner/skyscanner-python-sdk)
 
 ### [Slack](https://slack.com/) - Team Communication Platform
 - [API Documentation](https://api.slack.com/)


### PR DESCRIPTION
Added the following links:

- API Doc: http://business.skyscanner.net/portal/en-GB/Documentation/ApiOverview
- Github repo: https://github.com/Skyscanner/skyscanner-python-sdk
- Skyscanner website: http://www.skyscanner.net/

Thanks!