### PR TITLE
Added News Api headlines fetcher API wrapper

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -340,6 +340,10 @@ Hi. Below you will find a list of web services along with links to their docs an
 - [API Documentation](https://developer.nytimes.com/archive_api.json)
 - [Python wrapper](https://github.com/davidcox143/nytimesarchive)
 
+### [News API](https://newsapi.org/) - JSON metadata for the headlines currently published on a range of news sources and blogs
+- [API Documentation](https://newsapi.org/#documentation)
+- [Python wrapper for News API](https://github.com/SlapBot/newsapi)
+
 ### [OneTimeSecret](https://onetimesecret.com/) - Self-destructing messaging service
 - [API Documentation](https://onetimesecret.com/docs/api)
 - [Python wrapper for OneTimeSecret](https://github.com/utter-step/py_onetimesecret)


### PR DESCRIPTION
News API is a simple and easy-to-use API that returns JSON metadata for the headlines currently published on a range of news sources and blogs.