### PR TITLE
update newsapi to reflect up-to-date and endorsed sdk

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -398,8 +398,8 @@ Hi. Below you will find a list of web services along with links to their docs an
 - [Python wrapper](https://github.com/davidcox143/nytimesarchive)
 
 ### [News API](https://newsapi.org/) - JSON API for live news and blog headlines
-- [API Documentation](https://newsapi.org/#documentation)
-- [Python wrapper](https://github.com/SlapBot/newsapi)
+- [API Documentation](https://newsapi.org/docs)
+- [Python wrapper](https://github.com/mattlisiv/newsapi-python)
 
 ### [OneTimeSecret](https://onetimesecret.com/) - Self-destructing messaging service
 - [API Documentation](https://onetimesecret.com/docs/api)


### PR DESCRIPTION
I would like propose another Newsapi.org client library.

The currently suggested API wrapper appears unmaintained.

I have updated the readme with the actively maintained and 'unofficially endorsed' newsapi.org library.


![screenshot from 2018-10-03 12-18-11](https://user-images.githubusercontent.com/32674032/46386862-6de57500-c6b3-11e8-9510-59a53f3faf03.png)
[source](https://newsapi.org/docs/client-libraries/python)